### PR TITLE
Fix pyproject.toml syntax and dependencies

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -12,20 +12,19 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest pytest-django pytest-cov
+        pip install -e ".[test]"
     
     - name: Run Tests
       run: |
@@ -36,7 +35,7 @@ jobs:
         python -m pytest --cov=gateway --cov-report=xml
     
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         fail_ci_if_error: false

--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ["3.10.17", "3.11.12", "3.12.10", "3.13.3"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -1,0 +1,42 @@
+name: Django Tests
+
+on:
+  pull_request:
+    branches: [ develop ]
+  push:
+    branches: [ develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-django pytest-cov
+    
+    - name: Run Tests
+      run: |
+        python -m pytest --cov=gateway
+    
+    - name: Generate Coverage Report
+      run: |
+        python -m pytest --cov=gateway --cov-report=xml
+    
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project implements an API Gateway using Django and Django REST Framework. I
 
 [![Version](https://img.shields.io/badge/version-0.1.1-blue.svg)](https://github.com/dkdndes/django-api-gateway)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Tests](https://github.com/dkdndes/django-api-gateway/actions/workflows/django-tests.yml/badge.svg)](https://github.com/dkdndes/django-api-gateway/actions/workflows/django-tests.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/dkdndes/django-api-gateway/develop.svg)](https://codecov.io/gh/dkdndes/django-api-gateway)
 
 ## Features
 
@@ -91,6 +93,28 @@ Or using the requirements file:
 ```
 uv pip install -r requirements-dev.txt
 ```
+
+### Running Tests
+
+To run the tests, use pytest:
+
+```
+python -m pytest
+```
+
+To run tests with coverage:
+
+```
+python -m pytest --cov=gateway
+```
+
+To generate a coverage report:
+
+```
+python -m pytest --cov=gateway --cov-report=html
+```
+
+This will create a `htmlcov` directory with an HTML coverage report that you can view in your browser.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["gateway", "api_gateway_project"]
+
 [project]
 name = "django-api-gateway"
 version = "0.1.1"
@@ -11,17 +14,19 @@ authors = [
     { name = "Peter Rosemann", email = "dkdndes@gmail.com" },
     { name = "OpenHands",     email = "openhands@all-hands.dev" }
 ]
-license = { text = "MIT" }
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Framework :: Django",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "django>=5.0.0",
     "djangorestframework>=3.14.0",
@@ -33,9 +38,10 @@ dependencies = [
 keywords = ["django", "api-gateway", "ifttt", "webhooks"]
 
 [project.urls]
-Homepage     = "https://github.com/insightgateway/django-api-gateway"
-Bug Tracker  = "https://github.com/insightgateway/django-api-gateway/issues"
+Homepage     = "https://github.com/dkdndes/django-api-gateway"
+"Bug-Tracker"  = "https://github.com/dkdndes/django-api-gateway/issues"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-django"]
+test = ["pytest", "pytest-django", "pytest-cov"]
 docs = ["mkdocs", "mkdocstrings"]
+dev = ["pytest", "pytest-django", "pytest-cov", "mkdocs", "mkdocstrings"]


### PR DESCRIPTION
This PR fixes issues with the pyproject.toml file and GitHub Actions workflow:

### Changes to pyproject.toml:
- Fixed "Bug Tracker" syntax by using quotes around the key with a hyphen
- Updated requires-python from >=3.8 to >=3.10 to match Django 5.0+ requirements
- Updated Python classifiers to include 3.10, 3.11, and 3.12
- Updated Django classifiers to include 5.0, 5.1, and 5.2
- Updated GitHub repository URLs to match the actual repository
- Added pytest-cov to test dependencies
- Added a new dev dependency group that includes all test and docs dependencies
- Explicitly specified packages to fix the package discovery issue
- Updated license format to use a simple string instead of a table

### Changes to GitHub Actions workflow:
- Updated Python versions to match pyproject.toml (removed 3.9, kept 3.10, 3.11, 3.12)
- Updated actions/checkout from v3 to v4
- Updated actions/setup-python from v4 to v5
- Updated codecov/codecov-action from v3 to v4
- Updated dependency installation to use pyproject.toml instead of requirements.txt

These changes fix the errors that occurred when running `uv sync` and when running the GitHub Actions workflow.