### PR TITLE
Improve test coverage for middleware and management commands

### DIFF
--- a/gateway/tests/test_management_commands.py
+++ b/gateway/tests/test_management_commands.py
@@ -1,0 +1,78 @@
+import pytest
+from io import StringIO
+from django.core.management import call_command
+from gateway.models import Domain, ApiEndpoint, RequestTransformation, ResponseTransformation
+
+
+@pytest.mark.django_db
+def test_create_test_data_command():
+    """Test the create_test_data management command"""
+    # Call the command
+    out = StringIO()
+    call_command('create_test_data', stdout=out)
+    
+    # Check the output
+    output = out.getvalue()
+    assert 'Creating test domains' in output
+    assert 'Creating test endpoints' in output
+    assert 'Creating test transformations' in output
+    assert 'Test data creation completed!' in output
+    
+    # Verify the data was created
+    # Check domains
+    assert Domain.objects.filter(name='jsonplaceholder').exists()
+    assert Domain.objects.filter(name='httpbin').exists()
+    
+    # Check endpoints
+    jsonplaceholder = Domain.objects.get(name='jsonplaceholder')
+    httpbin = Domain.objects.get(name='httpbin')
+    
+    assert ApiEndpoint.objects.filter(domain=jsonplaceholder, path='/posts', method='GET').exists()
+    assert ApiEndpoint.objects.filter(domain=jsonplaceholder, path='/posts/{id}', method='GET').exists()
+    assert ApiEndpoint.objects.filter(domain=jsonplaceholder, path='/posts', method='POST').exists()
+    assert ApiEndpoint.objects.filter(domain=httpbin, path='/get', method='GET').exists()
+    assert ApiEndpoint.objects.filter(domain=httpbin, path='/post', method='POST').exists()
+    
+    # Check transformations
+    create_post_endpoint = ApiEndpoint.objects.get(domain=jsonplaceholder, path='/posts', method='POST')
+    post_endpoint = ApiEndpoint.objects.get(domain=httpbin, path='/post', method='POST')
+    
+    assert RequestTransformation.objects.filter(
+        endpoint=create_post_endpoint,
+        source_field='title',
+        target_field='title',
+        transformation_type='template'
+    ).exists()
+    
+    assert ResponseTransformation.objects.filter(
+        endpoint=post_endpoint,
+        source_field='data',
+        target_field='transformed_data',
+        transformation_type='direct'
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_test_data_command_idempotent():
+    """Test that the create_test_data command is idempotent"""
+    # Call the command twice
+    out1 = StringIO()
+    call_command('create_test_data', stdout=out1)
+    
+    out2 = StringIO()
+    call_command('create_test_data', stdout=out2)
+    
+    # Check the output of the second call
+    output = out2.getvalue()
+    assert 'Domain already exists: jsonplaceholder' in output
+    assert 'Domain already exists: httpbin' in output
+    assert 'Endpoint already exists:' in output
+    assert 'Request transformation already exists:' in output
+    assert 'Response transformation already exists:' in output
+    
+    # Verify we don't have duplicates
+    assert Domain.objects.filter(name='jsonplaceholder').count() == 1
+    assert Domain.objects.filter(name='httpbin').count() == 1
+    
+    jsonplaceholder = Domain.objects.get(name='jsonplaceholder')
+    assert ApiEndpoint.objects.filter(domain=jsonplaceholder, path='/posts', method='GET').count() == 1

--- a/gateway/tests/test_middleware.py
+++ b/gateway/tests/test_middleware.py
@@ -1,0 +1,256 @@
+import json
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+from django.test import RequestFactory
+from django.http import HttpResponse, JsonResponse
+from gateway.middleware import ApiGatewayMiddleware
+from gateway.models import Domain, ApiEndpoint, RequestTransformation, ResponseTransformation, ApiLog
+
+
+@pytest.fixture
+def middleware():
+    """Create a middleware instance with a mock get_response function"""
+    get_response = MagicMock(return_value=HttpResponse("Default response"))
+    return ApiGatewayMiddleware(get_response)
+
+
+@pytest.fixture
+def request_factory():
+    """Create a request factory for generating test requests"""
+    return RequestFactory()
+
+
+@pytest.fixture
+def domain(db):
+    """Create a test domain"""
+    return Domain.objects.create(
+        name="example.com",
+        base_url="https://example.com",
+        description="Test domain",
+        is_active=True
+    )
+
+
+@pytest.fixture
+def api_endpoint(db, domain):
+    """Create a test API endpoint"""
+    return ApiEndpoint.objects.create(
+        domain=domain,
+        path="/test",
+        method="GET",
+        target_url="https://example.com/api/test",
+        timeout=30,
+        is_active=True
+    )
+
+
+@pytest.mark.django_db
+def test_should_handle_request_admin_path(middleware, request_factory):
+    """Test that admin paths are not handled by the middleware"""
+    request = request_factory.get("/admin/login/")
+    assert middleware._should_handle_request(request) is False
+
+
+@pytest.mark.django_db
+def test_should_handle_request_api_path(middleware, request_factory):
+    """Test that API paths are handled by the middleware"""
+    request = request_factory.get("/api/test")
+    assert middleware._should_handle_request(request) is True
+
+
+@pytest.mark.django_db
+def test_should_handle_request_with_matching_endpoint(middleware, request_factory, api_endpoint):
+    """Test that paths with matching endpoints are handled by the middleware"""
+    # Set up the request with the correct host
+    request = request_factory.get("/test")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # This should match our api_endpoint fixture
+    assert middleware._should_handle_request(request) is True
+
+
+@pytest.mark.django_db
+def test_should_handle_request_with_no_matching_endpoint(middleware, request_factory, domain):
+    """Test that paths without matching endpoints are not handled by the middleware"""
+    request = request_factory.get("/nonexistent")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # No endpoint matches this path
+    assert middleware._should_handle_request(request) is False
+
+
+@pytest.mark.django_db
+def test_normalize_path(middleware):
+    """Test path normalization"""
+    assert middleware._normalize_path("/test/") == "/test"
+    assert middleware._normalize_path("/test") == "/test"
+    assert middleware._normalize_path("/") == "/"
+
+
+@pytest.mark.django_db
+@patch("gateway.middleware.requests.get")
+def test_handle_api_gateway_request_success(mock_get, middleware, request_factory, api_endpoint):
+    """Test successful API gateway request handling"""
+    # Mock the response from the external service
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {"data": "test_data"}
+    mock_response.text = json.dumps({"data": "test_data"})
+    mock_get.return_value = mock_response
+    
+    # Create a request that matches our api_endpoint
+    request = request_factory.get("/test")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # Call the middleware
+    response = middleware._handle_api_gateway_request(request)
+    
+    # Verify the response
+    assert response.status_code == 200
+    assert "application/json" in response["Content-Type"]
+    assert json.loads(response.content) == {"data": "test_data"}
+    
+    # Verify the external service was called correctly
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://example.com/api/test"
+
+
+@pytest.mark.django_db
+@patch("gateway.middleware.requests.get")
+def test_handle_api_gateway_request_not_found(mock_get, middleware, request_factory, domain):
+    """Test API gateway request handling when no endpoint is found"""
+    # Create a request with a path that doesn't match any endpoint
+    request = request_factory.get("/nonexistent")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # Call the middleware
+    response = middleware._handle_api_gateway_request(request)
+    
+    # Verify the response is a 404
+    assert response.status_code == 404
+    assert "application/json" in response["Content-Type"]
+    response_data = json.loads(response.content)
+    assert response_data["error"] == "Not Found"
+    
+    # Verify no external service was called
+    mock_get.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("gateway.middleware.requests.get")
+def test_handle_api_gateway_request_error(mock_get, middleware, request_factory, api_endpoint):
+    """Test API gateway request handling when the external service returns an error"""
+    # Mock the response from the external service to raise an exception
+    mock_get.side_effect = requests.RequestException("Connection error")
+    
+    # Create a request that matches our api_endpoint
+    request = request_factory.get("/test")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # Call the middleware
+    response = middleware._handle_api_gateway_request(request)
+    
+    # Verify the response is a 502
+    assert response.status_code == 502
+    assert "application/json" in response["Content-Type"]
+    response_data = json.loads(response.content)
+    assert response_data["error"] == "Gateway Error"
+    
+    # Verify the external service was called
+    mock_get.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_get_nested_value(middleware):
+    """Test getting nested values from dictionaries"""
+    data = {
+        "a": 1,
+        "b": {
+            "c": 2,
+            "d": {
+                "e": 3
+            }
+        },
+        "f": [{"g": 4}, {"g": 5}]
+    }
+    
+    assert middleware._get_nested_value(data, "a") == 1
+    assert middleware._get_nested_value(data, "b.c") == 2
+    assert middleware._get_nested_value(data, "b.d.e") == 3
+    assert middleware._get_nested_value(data, "f.0.g") == 4
+    assert middleware._get_nested_value(data, "f.1.g") == 5
+    assert middleware._get_nested_value(data, "nonexistent") is None
+    assert middleware._get_nested_value(data, "b.nonexistent") is None
+
+
+@pytest.mark.django_db
+def test_set_nested_value(middleware):
+    """Test setting nested values in dictionaries"""
+    data = {
+        "a": 1,
+        "b": {
+            "c": 2
+        }
+    }
+    
+    # Set existing top-level key
+    middleware._set_nested_value(data, "a", 10)
+    assert data["a"] == 10
+    
+    # Set existing nested key
+    middleware._set_nested_value(data, "b.c", 20)
+    assert data["b"]["c"] == 20
+    
+    # Set new top-level key
+    middleware._set_nested_value(data, "d", 30)
+    assert data["d"] == 30
+    
+    # Set new nested key in existing path
+    middleware._set_nested_value(data, "b.e", 40)
+    assert data["b"]["e"] == 40
+    
+    # Set new nested key in new path
+    middleware._set_nested_value(data, "f.g", 50)
+    assert data["f"]["g"] == 50
+
+
+@pytest.mark.django_db
+@patch("gateway.middleware.ApiLog")
+def test_log_request(mock_api_log_class, middleware, request_factory, api_endpoint):
+    """Test request logging"""
+    request = request_factory.get("/test")
+    request.META["HTTP_HOST"] = "example.com"
+    
+    # Set up the mock ApiLog instance
+    mock_api_log = MagicMock()
+    mock_api_log_class.return_value = mock_api_log
+    
+    # Call the log_request method
+    middleware._log_request(
+        endpoint=api_endpoint,
+        request=request,
+        request_body={"test": "data"},
+        response_status=200,
+        response_headers={"Content-Type": "application/json"},
+        response_body=json.dumps({"result": "success"}),
+        execution_time=0.5
+    )
+    
+    # Verify the log was created with correct parameters
+    mock_api_log_class.assert_called_once()
+    args, kwargs = mock_api_log_class.call_args
+    assert kwargs["endpoint"] == api_endpoint
+    assert kwargs["request_method"] == "GET"
+    assert kwargs["request_path"] == "/test"
+    assert kwargs["response_status"] == 200
+    assert kwargs["execution_time"] == 0.5
+    
+    # Verify set_request_headers and set_response_headers were called
+    mock_api_log.set_request_headers.assert_called_once()
+    mock_api_log.set_response_headers.assert_called_once()
+    
+    # Verify save was called
+    mock_api_log.save.assert_called_once()


### PR DESCRIPTION
This PR adds comprehensive tests for the middleware and management commands, significantly improving the overall test coverage from 39% to 62%.

### Changes:

- Added test_middleware.py with 11 tests covering the ApiGatewayMiddleware functionality
- Added test_management_commands.py with 2 tests for the create_test_data command
- Increased middleware.py coverage from 13% to 51%
- Achieved 100% coverage for management commands
- Increased models.py coverage from 87% to 94%

### Coverage Report:

```
Name                                              Stmts   Miss  Cover
---------------------------------------------------------------------
gateway/management/commands/create_test_data.py      45      0   100%
gateway/middleware.py                               224    110    51%
gateway/models.py                                    69      4    94%
gateway/serializers.py                               26      0   100%
gateway/tests.py                                      1      1     0%
gateway/urls.py                                      14      0   100%
gateway/views.py                                    212    108    49%
---------------------------------------------------------------------
TOTAL                                               591    223    62%
```